### PR TITLE
Mrd 2729/concurrent and consecutive data

### DIFF
--- a/e2e_tests/stepDefinitions/ppcs/ppcs.steps.ts
+++ b/e2e_tests/stepDefinitions/ppcs/ppcs.steps.ts
@@ -186,8 +186,11 @@ Then('the user proceeds to book a {custodyGroup} sentence recall', function(cust
 
   if (custodyGroup === CUSTODY_GROUP.DETERMINATE) {
     cy.pageHeading().should('contain', 'Select the index offence for ')
-    selectRandomRadio('.govuk-radios') // Forced to select by class at the moment as no id
+    selectRadio('indexOffence', '3934359')
     cy.clickButton('Continue')
+
+    cy.pageHeading().should('equal', 'Check the index offence and its consecutive sentences')
+    cy.clickLink('Continue')
 
     cy.pageHeading().should('equal', 'Select a matching index offence in PPUD')
     selectRandomAutocompleteOption('indexOffence')

--- a/e2e_tests/stepDefinitions/ppcs/ppcs.steps.ts
+++ b/e2e_tests/stepDefinitions/ppcs/ppcs.steps.ts
@@ -189,7 +189,7 @@ Then('the user proceeds to book a {custodyGroup} sentence recall', function(cust
     selectRadio('indexOffence', '3934359')
     cy.clickButton('Continue')
 
-    cy.pageHeading().should('equal', 'Check the index offence and its consecutive sentences')
+    cy.pageHeading().should('equal', 'View the index offence and its consecutive sentences')
     cy.clickLink('Continue')
 
     cy.pageHeading().should('equal', 'Select a matching index offence in PPUD')


### PR DESCRIPTION
Following the introduction of the consecutive sentence details page by https://github.com/ministryofjustice/make-recall-decision-api/pull/1176 and https://github.com/ministryofjustice/make-recall-decision-ui/pull/1381, add this page into the standard determinate journey to ensure we can hit it as expected.