### PR TITLE
MRD-3033 Update checkbox symbol

### DIFF
--- a/e2e_tests/stepDefinitions/assertionsPartA.ts
+++ b/e2e_tests/stepDefinitions/assertionsPartA.ts
@@ -380,9 +380,13 @@ export const q16IndexOffenceDetails = (contents: string, answer: string = apiDat
 export const q17LicenceConditions = (contents: string, details: string[]) => {
   // eslint-disable-next-line no-param-reassign
   contents = contents.substring(contents.indexOf(partASections[17]), contents.indexOf(partASections[18]))
-  details.forEach(detail => {
+  Object.keys(LicenceConditions).forEach(licenceCondition => {
     expectSoftly(contents, 'Licence Conditions').to.match(
-      new RegExp(`${LicenceConditions[detail].replace(REGEXP_SPECIAL_CHAR, '\\$&')}\\s*✓`)
+      new RegExp(
+        `${LicenceConditions[licenceCondition].replace(REGEXP_SPECIAL_CHAR, '\\$&')}\\s*${
+          details.includes(licenceCondition) ? '☒' : '☐'
+        }`
+      )
     )
   })
 }

--- a/e2e_tests/support/enums.ts
+++ b/e2e_tests/support/enums.ts
@@ -69,7 +69,6 @@ export enum LicenceConditions {
   NO_TRAVEL_OUTSIDE_UK = 'not to travel outside the United Kingdom, the Channel Islands or the Isle of Man except with the prior permission of your supervising officer or for the purpose of immigration deportation or removal.',
   NAME_CHANGE = 'Tell your supervising officer if you use a name which is different to the name or names which appear on your licence.',
   CONTACT_DETAILS = 'Tell your supervising officer if you change or add any contact details, including phone number or email.',
-  'NLC8|NSTT8' = 'To only attend places of worship which have been previously agreed with your supervising officer.',
 }
 
 export enum WhyConsiderRecall {


### PR DESCRIPTION
The symbol we shown in Part As for selected and unselected elements has been
updated as part of the FTR56 changes: before we left it empty for unselected
and added a single tick symbol for selected, now replaced with an empty and a
checked checkbox respectively. This was accidentally done in a way that also
affected the existing code, not just the FTR56 one. However, undoing that just
for FTR56 would be more trouble than it's worth, so we're updating things here
to simply expect the new symbols even for the old pre-FTR56 template. This has
been OKed by the UCD team, as this will only affect a last few Part As
generated before the FTR56 switchover and the symbols are readable and
consistent with the old template too.

A licence condition no longer in use has also been removed.