### PR TITLE
MRD-3033 Use e2e-test-repo-ftr56 spring profile

### DIFF
--- a/scripts/start-services-integration.sh
+++ b/scripts/start-services-integration.sh
@@ -18,14 +18,8 @@ docker compose -f "${API_DIR}/docker-compose.yml" pull
 
 pushd "${API_DIR}"
 printf "\n\nBuilding/starting API components...\n\n"
-export SPRING_PROFILES_ACTIVE=dev,seed-test-data
-# temporary, in order to test the new tamplate in the ftr56 branch. Should be undone once FTR56 is released.
-export DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_0_STARTDATETIME="2025-08-20T23:00Z" # 2025-08-21T00:00Z in BST, bring forward dev for testing
-export DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_0_TEMPLATENAME="2025-09-02 - FTR48 Phase 1"
-export DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_1_STARTDATETIME="2026-01-28T00:00Z" # same time in GMT
-export DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_1_TEMPLATENAME="2026-02-02 - Risk to self"
-export DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_2_STARTDATETIME="2026-03-23T00:00Z" # same time in GMT, brought forward for testing in FTR56 e2e branch
-export DOCUMENTTEMPLATE_PARTATEMPLATESETTINGS_2_TEMPLATENAME="2026-03-31 - FTR56"
+# e2e-test-repo-ftr56 added for FTR56 testing - to be removed once merging into main
+export SPRING_PROFILES_ACTIVE=dev,seed-test-data,e2e-test-repo-ftr56
 export POSTGRES_OPTIONS=sslmode=disable
 docker compose build
 docker compose up -d


### PR DESCRIPTION
A new e2e-test-repo-ftr56 spring profile config file has been added to the API
service to allow more granular control of the config values when running the
e2e tests from the e2e repo, as the dev and seed-test-data ones are used
elsewhere and didn't allow to configure as tightly as needed.