### PR TITLE
MRD-3127 Update task-list-consider-recall navigation

### DIFF
--- a/e2e_tests/stepDefinitions/index.ts
+++ b/e2e_tests/stepDefinitions/index.ts
@@ -161,7 +161,6 @@ Then('Part A details are correct', function () {
 
 When('PO returns to Recommendations page of CRN', function () {
   cy.clickLink(`Back`)
-  cy.clickLink('Back')
   cy.clickLink('Recommendations')
 })
 


### PR DESCRIPTION
The back link for task-list-consider-recall now task the user straight to the
overview page. The command to navigate back to the latter page now requires one
fewer 'Back' button click.