### PR TITLE
Fix timezone issues

### DIFF
--- a/e2e_tests/stepDefinitions/assertionsPartA.ts
+++ b/e2e_tests/stepDefinitions/assertionsPartA.ts
@@ -4,8 +4,6 @@ import {
   changeDateFromLongFormatToShort,
   formatObjectDateToLongFormat,
   getTestDataPerEnvironment,
-  formatDateToCompletedDocumentFormat,
-  formattedTimeFromDateIn24HrFormat,
 } from '../utils'
 import {
   Alternatives,
@@ -529,14 +527,16 @@ export const q23ProbationDetailsWithCaseAdmin = (
   expectSoftly(contents, 'Probation-Officer-Region').to.contain(`Region: ${whoCompletedPartADetails.region}`)
   expectSoftly(contents, 'Probation-Officer-LDU').to.contain(`LDU: ${whoCompletedPartADetails.LDU}`)
   expectSoftly(contents, 'Probation-Date of Decision').to.contain(
-    `Date of decision to request revocation: ${formatDateToCompletedDocumentFormat(date.recallDateBySPO as unknown as Date)}`
+    `Date of decision to request revocation: ${DateTime.fromJSDate(date.recallDateBySPO as unknown as Date).toFormat(
+      'dd/MM/yyyy'
+    )}`
   )
   // TODO check PPCS responses e-mail address once task-list-consider-recall changes merged
 
   expectSoftly(contents, 'Probation-Time of Decision').to.contain(
-    `Time (24 hour) of decision to request information: ${formattedTimeFromDateIn24HrFormat(
+    `Time (24 hour) of decision to request information: ${DateTime.fromJSDate(
       date.recallDateBySPO as unknown as Date
-    )}`
+    ).toFormat('HH:mm')}`
   )
 }
 

--- a/e2e_tests/utils/index.ts
+++ b/e2e_tests/utils/index.ts
@@ -18,37 +18,9 @@ export const getTestDataPerEnvironment = () => {
   }
 }
 
-export const isoDateToObject = (isoDate: string) => {
-  const d = DateTime.fromISO(isoDate)
-  const { day, month, year } = d.toObject()
-  return { day, month, year }
-}
-
 export const formatObjectDateToLongFormat = (objectDate: Record<string, number | string>) => {
   const d = DateTime.fromObject(objectDate)
   return d.toFormat('d MMMM yyyy')
-}
-
-export const formatDateToCompletedDocumentFormat = (date: Date) => {
-  const day = date.getDate()
-  const month = date.getMonth() + 1
-  const year = date.getFullYear()
-
-  const formattedDay = day < 10 ? `0${day}` : `${day}`
-  const formattedMonth = month < 10 ? `0${month}` : `${month}`
-
-  return `${formattedDay}/${formattedMonth}/${year}`
-}
-
-export const extractTimeFromUTCDateFormat = (inputDate: string) => {
-  const date = new Date(inputDate)
-  const hours = date.getUTCHours()
-  const minutes = date.getUTCMinutes()
-
-  const formattedHours = hours < 10 ? `0${hours}` : `${hours}`
-  const formattedMin = minutes < 10 ? `0${minutes}` : `${minutes}`
-
-  return `${formattedHours}:${formattedMin}`
 }
 
 export const formatCurrentDateToCompletedDocumentFormat = () => {
@@ -58,17 +30,6 @@ export const formatCurrentDateToCompletedDocumentFormat = () => {
 
 export const changeDateFromLongFormatToShort = (dateToConvert: string) => {
   return DateTime.fromFormat(dateToConvert, 'd MMMM yyyy').toFormat('dd/MM/yyyy')
-}
-
-export const formattedTimeFromDateIn24HrFormat = (date: Date) => {
-  const options: Intl.DateTimeFormatOptions = {
-    timeZone: 'Europe/London',
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-  }
-  const currentTime: string = date.toLocaleTimeString('en-GB', options)
-  return currentTime
 }
 
 export const formatDateToDNTRLetterFormat = (objectDate: Date) => {


### PR DESCRIPTION
The expected string and actual string were using different timezones
when printing the date and time. This has been fixed.

Unused functions in utils/index.ts have also been removed.