### PR TITLE
Fix dev test issues

### DIFF
--- a/cypress_shared/commands.ts
+++ b/cypress_shared/commands.ts
@@ -389,10 +389,10 @@ Cypress.Commands.add('getOffenderDetails', () => {
     offenderDetails.ethnicity = replaceMissingNDeliusInfoWithNotSpecified(text)
   })
   cy.getDefinitionListValue('Spoken').then(text => {
-    offenderDetails.spokenLanguage = text
+    offenderDetails.spokenLanguage = replaceMissingNDeliusInfoWithBlank(text)
   })
   cy.getDefinitionListValue('Written').then(text => {
-    offenderDetails.writtenLanguage = text
+    offenderDetails.writtenLanguage = replaceMissingNDeliusInfoWithBlank(text)
   })
   cy.getDefinitionListValue('CRO number').then(text => {
     offenderDetails.cro = replaceMissingNDeliusInfoWithBlank(text)

--- a/e2e_tests/stepDefinitions/assertionsPartA.ts
+++ b/e2e_tests/stepDefinitions/assertionsPartA.ts
@@ -137,7 +137,7 @@ export const q6OffenderDetails = function (
       : (apiDataForCrn.ethnicity as RegExp)
   )
   expectSoftly(contents, 'Offender-Written language').to.contain(`Written: ${context.writtenLanguage}`)
-  expectSoftly(contents, 'Offender-Written language').to.contain(`Spoken: ${context.spokenLanguage}`)
+  expectSoftly(contents, 'Offender-Spoken language').to.contain(`Spoken: ${context.spokenLanguage}`)
   expectSoftly(contents, 'Offender-Gender').to.contain(`Gender: ${context.gender}`)
   expectSoftly(contents, 'Offender-CRN').to.contain(`CRN: ${crn}`)
   expectSoftly(contents, 'Offender-CRO').to.match(
@@ -171,12 +171,12 @@ export const q6OffenderDetails = function (
 export const q7SentenceDetails = function (contents: string, context: Record<string, string>) {
   // eslint-disable-next-line no-param-reassign
   contents = contents.substring(contents.indexOf(partASections[7]), contents.indexOf(partASections[8]))
-  cy.log(`q5: ${JSON.stringify(context)} ${contents}`)
+  cy.log(`q7: ${JSON.stringify(context)} ${contents}`)
   expectSoftly(contents, 'Sentence Details-Index offence').to.contain(
     `Index offence of current sentence which has led to the offender’s recall: ${context.indexOffenceDescription}`
   )
-  cy.log(`q5 from api-- ${apiDataForCrn.dateOfOriginalOffence}`)
-  cy.log(`q5 from context---- ${context.dateOfOriginalOffence}`)
+  cy.log(`q7 from api-- ${apiDataForCrn.dateOfOriginalOffence}`)
+  cy.log(`q7 from context---- ${context.dateOfOriginalOffence}`)
 
   expectSoftly(contents, 'Sentence Details-Dates of Original Offence').to.match(
     context.dateOfOriginalOffence

--- a/e2e_tests/stepDefinitions/index.ts
+++ b/e2e_tests/stepDefinitions/index.ts
@@ -32,8 +32,8 @@ import { CUSTODY_GROUP, CustodyType, SentenceGroup, YesNoType } from '../support
 import { loginAndSearchCrn } from './user/user'
 
 export const crns = {
-  1: Cypress.env('CRN') || 'X514364',
-  2: Cypress.env('CRN2') || 'X514364',
+  // 1: Cypress.env('CRN') || 'X514364', // Removed temporarily. This CRN has MAPPA data such that FTR is never possible, which causes issues with FTR tests
+  // 2: Cypress.env('CRN2') || 'X514364',
   3: Cypress.env('CRN3') || 'X487027',
   4: Cypress.env('CRN4') || 'X487027',
   // 5: Cypress.env('CRN5') || 'D002399', // Removed temporarily. This CRN doesn't have an address, and causes an error on the addressDetails page


### PR DESCRIPTION
A couple of problems have been found with the e2e test runs in dev after the
FTR56 changes:
  - One of the PoPs used has MAPPA information such that, in case of recalling,
    a Standard recall is mandatory for Adult SDS cases. This lets our Adult SDS
    FTR tests fail, as they cannot find the FTR radio button option in the
    relevant screen. The relevant CRN has been removed from the test data for
    now. Further discussions will be had on this over whether to introduce
    better PoPs into dev for our testing or to remove e2e testing from dev
    altogether.
  - The remaining dev PoP in use for e2e testing has no written or spoken
    language information in NDelius, a case not contemplated by the code so far
    (pre-FTR56 versions of the text collected this information but never
    checked it in the Part A, so it had never been an issue). This has been
    fixed.