### PR TITLE
MRD-3245 upgrade GHA checkout action

### DIFF
--- a/.github/workflows/e2e_local_tests.yml
+++ b/.github/workflows/e2e_local_tests.yml
@@ -36,21 +36,24 @@ jobs:
       timings-6: ${{ steps.timings.outputs.t6 }}
     steps:
       - name: Check out make-recall-decision-api repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'ministryofjustice/make-recall-decision-api'
           path: 'make-recall-decision-api'
+          persist-credentials: false
       - name: Check out make-recall-decision-ui repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'ministryofjustice/make-recall-decision-ui'
           path: 'make-recall-decision-ui'
+          persist-credentials: false
       - name: Check out make-recall-decision-e2e-tests repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'ministryofjustice/make-recall-decision-e2e-tests'
           ref: ${{ inputs.ui-branch_name }}
           path: 'make-recall-decision-e2e-tests'
+          persist-credentials: false
       - name: Use Node.js .nvmrc
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
This one's _slightly_ confusing in that it's using the ARNs `cypress_get_timings` action which is still using an older version of the GHA actions/checkout (v4), but when we're doing the checkout ourselves it'll be using the new v7 checkout action