### PR TITLE
Enable npm checks

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,0 +1,6 @@
+{
+  "low": true,
+  "package-manager": "auto",
+  "registry": "https://registry.npmjs.org",
+  "allowlist": []
+}


### PR DESCRIPTION
The npm check pipeline step requires the audit-ci.json file.