### PR TITLE
update steps for uploading logs to use correct command

### DIFF
--- a/.github/workflows/e2e_local_tests.yml
+++ b/.github/workflows/e2e_local_tests.yml
@@ -109,11 +109,11 @@ jobs:
       - name: Record API docker logs
         if: failure()
         working-directory: make-recall-decision-api
-        run: docker-compose logs
+        run: docker compose logs
       - name: Record UI docker logs
         if: failure()
         working-directory: make-recall-decision-ui
-        run: docker-compose logs
+        run: docker compose logs
       - name: Upload screenshots
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
When a job fails in this repo whilst running the `run e2e tests locally` action, it attempts to upload docker logs to the job as artefacts, but the command is currently `docker-compose logs` rather than `docker compose logs` which is causing it to fail. 

This PR fixes that.